### PR TITLE
fixing link to published image

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ urlFragment: confidential-aci-samples
 
 This sample is a basic Python application used to demonstrate [Confidential Containers on Azure Container Instances](aka.ms/aci). In this sample an AMD SEV SNP report containing the container groups firmware measurements will be displayed in a Python Flask web application.
 
-The packaged version of this application is available on [Microsoft Container Registry](https://registry.hub.docker.com/_/microsoft-azuredocs-aci-helloworld?tab=description).
+The packaged version of this application is available on [Microsoft Container Registry](https://mcr.microsoft.com/v2/aci/aci-confidential-helloworld/tags/list).
 
 ![Hello World Hardware Report](./media/hello-world-cc.png)
 
@@ -25,7 +25,6 @@ The packaged version of this application is available on [Microsoft Container Re
 
 * [Deploy via Portal](https://aka.ms/aciccportal)
 * [Deploy via ARM with a custom confidential computing enforcement policy](https://aka.ms/aciccarm)
-
 
 ## Contributing
 


### PR DESCRIPTION
## Purpose
The link in the README is incorrectly pointing to non-confidential ACI's image

## Does this introduce a breaking change?

```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x ] Documentation content changes
[ ] Other... Please describe:
```


## Other Information
I could not find an analogous link on docker hub so it is now linking to a list of available tags for the image on MCR.